### PR TITLE
Add Cv newtype + #[xs_sub] Cv (coderef) argument kind

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,9 +627,9 @@ dependencies = [
 
 [[package]]
 name = "libperl-macrogen"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f20844a7f8e1c9018b4a4f4fad4c736277b80b93e6d81f7ad6f7aa2b11c4f1a"
+checksum = "16d90726976d6489348b3e0f39e02e7f8e22642375b6e0dda40d72086dcaa1f9"
 dependencies = [
  "clap",
  "flate2",

--- a/libperl-macros/src/xs_sub.rs
+++ b/libperl-macros/src/xs_sub.rs
@@ -71,6 +71,12 @@ enum ArgKind {
     /// `&Hv` — borrowed hash. Same dance as `InAvRef` but checks
     /// `SVt_PVHV`. Phase 3.10d.
     InHvRef,
+    /// `Cv` — the caller passes a CODE reference (`\&sub` or an
+    /// anonymous sub); the trampoline checks `SvROK` + `SVt_PVCV`,
+    /// croaks on mismatch, and hands the body an owned (`Copy`) `Cv`
+    /// handle to the referenced CV. Static-analysis entry points
+    /// (analyze a coderef's OP tree) are the motivating use case.
+    InCvRef,
 }
 
 #[derive(Clone)]
@@ -194,7 +200,9 @@ pub fn xs_sub(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 | ArgKind::InCStr
                 | ArgKind::InStr
                 | ArgKind::InRawSv
-                | ArgKind::InSv => quote! { #n },
+                | ArgKind::InSv
+                // `Cv` extraction binds `#n` as an owned (Copy) `Cv`.
+                | ArgKind::InCvRef => quote! { #n },
                 ArgKind::Out(_) => quote! { &mut #n },
                 // The trampoline injects a `__perl_ref: &Perl` local
                 // before calling the body fn (see `perl_ref_setup`).
@@ -369,7 +377,7 @@ pub fn xs_sub(_attr: TokenStream, item: TokenStream) -> TokenStream {
                         };
                     }
                 }
-                ArgKind::InAvRef | ArgKind::InHvRef => {
+                ArgKind::InAvRef | ArgKind::InHvRef | ArgKind::InCvRef => {
                     let (rust_ty, expected_svtype, type_str, ctor) = match spec.kind {
                         ArgKind::InAvRef => (
                             quote! { ::libperl_rs::Av },
@@ -382,6 +390,12 @@ pub fn xs_sub(_attr: TokenStream, item: TokenStream) -> TokenStream {
                             quote! { ::libperl_rs::svtype::SVt_PVHV },
                             "HASH",
                             quote! { ::libperl_rs::Hv::from_raw_unchecked },
+                        ),
+                        ArgKind::InCvRef => (
+                            quote! { ::libperl_rs::Cv },
+                            quote! { ::libperl_rs::svtype::SVt_PVCV },
+                            "CODE",
+                            quote! { ::libperl_rs::Cv::from_raw_unchecked },
                         ),
                         _ => unreachable!(),
                     };
@@ -818,6 +832,9 @@ fn classify_arg_type(ty: &Type) -> Option<ArgKind> {
     if is_sv_newtype(ty) {
         return Some(ArgKind::InSv);
     }
+    if is_cv_newtype(ty) {
+        return Some(ArgKind::InCvRef);
+    }
     classify_scalar(ty).map(ArgKind::In)
 }
 
@@ -886,6 +903,12 @@ fn is_raw_sv_ptr(ty: &Type) -> bool {
 fn is_sv_newtype(ty: &Type) -> bool {
     let Type::Path(TypePath { path, .. }) = ty else { return false };
     path.segments.last().is_some_and(|s| s.ident == "Sv" && s.arguments.is_none())
+}
+
+/// True when `ty` is the bare `Cv` newtype (CODE-reference argument).
+fn is_cv_newtype(ty: &Type) -> bool {
+    let Type::Path(TypePath { path, .. }) = ty else { return false };
+    path.segments.last().is_some_and(|s| s.ident == "Cv" && s.arguments.is_none())
 }
 
 /// True when `ty` is `Rv<...>` — any single-generic `Rv` path

--- a/libperl-sys/build.rs
+++ b/libperl-sys/build.rs
@@ -140,6 +140,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .allowlist_item("G_.*")
             .allowlist_item("regex_charset")
             .allowlist_item("SCX_enum")
+            // OP_ARGCHECK (signature) の aux 構造体と、
+            // OP_MULTIDEREF の aux アクション定数 (静的解析ツール向け)
+            .allowlist_item("op_argcheck_aux")
+            .allowlist_item("MDEREF_.*")
 
         // Finish the builder and generate the bindings.
             .generate()

--- a/runtest-docker.zsh
+++ b/runtest-docker.zsh
@@ -64,7 +64,7 @@ cmdList=()
 
 if (($#o_use_archive)); then
     distName=${o_use_archive[2]#=}
-    sourcesList="$(perl -s -le 'print <<END;
+    sourcesListContent="$(perl -s -le 'print <<END;
 deb http://archive.debian.org/debian/ $distName main
 deb-src http://archive.debian.org/debian/ $distName main
 
@@ -77,15 +77,34 @@ END
     cmdList+=(
         "cat /etc/apt/sources.list"
         "echo ==="
-        "echo '$sourcesList' > /etc/apt/sources.list"
+        "echo '$sourcesListContent' > /etc/apt/sources.list"
         "cat /etc/apt/sources.list"
-        "echo ==="
+        "echo === doing update"
+        'apt-get update'
+        "apt-get install -y $o_force_yes apt-transport-https ca-certificates"
+    )
+
+    sourcesListContent="$(perl -s -le 'print <<END;
+deb http://apt.llvm.org/$distName/ llvm-toolchain-$distName-5.0 main
+deb-src http://apt.llvm.org/$distName/ llvm-toolchain-$distName-5.0 main
+END
+' -- -distName=$distName)"
+
+
+    cmdList+=(
+        "echo '$sourcesListContent' >> /etc/apt/sources.list"
+        'apt-get update -o Acquire::Check-Valid-Until=false'
+        "apt-get install -y $o_force_yes clang-5.0 lldb-5.0 libclang-5.0-dev llvm-5.0-dev"
+    )
+
+else
+    cmdList+=(
+        'apt-get update'
+        "apt-get install -y $o_force_yes llvm-dev libclang-dev clang"
     )
 fi
 
 cmdList+=(
-    'apt update'
-    "apt install -y $o_force_yes llvm-dev libclang-dev clang"
     'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh'
     'sh rustup.sh -y'
     'source $HOME/.cargo/env'

--- a/runtest-docker.zsh
+++ b/runtest-docker.zsh
@@ -16,6 +16,8 @@ fi
 
 zparseopts -D -K x=o_xtrace n=o_dryrun \
            -reuse-target-dir=o_reuse_target_dir \
+           -use-debian-archive:=o_use_archive \
+           -force-yes=o_force_yes \
            -image:=o_image -target:=o_targetDir
 
 if (($#o_xtrace)); then set -x; fi
@@ -58,9 +60,32 @@ fi
 
 #========================================
 
-cmdList=(
+cmdList=()
+
+if (($#o_use_archive)); then
+    distName=${o_use_archive[2]#=}
+    sourcesList="$(perl -s -le 'print <<END;
+deb http://archive.debian.org/debian/ $distName main
+deb-src http://archive.debian.org/debian/ $distName main
+
+deb http://archive.debian.org/debian-security/ $distName/updates main
+deb-src http://archive.debian.org/debian-security/ $distName/updates main
+END
+' -- -distName=$distName)"
+
+
+    cmdList+=(
+        "cat /etc/apt/sources.list"
+        "echo ==="
+        "echo '$sourcesList' > /etc/apt/sources.list"
+        "cat /etc/apt/sources.list"
+        "echo ==="
+    )
+fi
+
+cmdList+=(
     'apt update'
-    'apt install -y llvm-dev libclang-dev clang'
+    "apt install -y $o_force_yes llvm-dev libclang-dev clang"
     'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh'
     'sh rustup.sh -y'
     'source $HOME/.cargo/env'

--- a/src/cv.rs
+++ b/src/cv.rs
@@ -1,0 +1,140 @@
+//! `Cv` newtype — a non-null handle to a Perl `CV` (code value).
+//!
+//! This is the first slice of "Step 2" in `docs/plan/README.md`
+//! (Cv/Op newtypes for OP-tree walkers). The accessors below cover
+//! what a static-analysis client needs to get from a coderef to its
+//! OP tree: `root` / `start` / `padlist` / `file` / `proto`, plus the
+//! `is_xsub` guard that must be checked before touching the
+//! `xcv_root_u` / `xcv_padlist_u` unions.
+//!
+//! All accessors delegate to the macrogen-emitted official API
+//! (`CvROOT`, `CvSTART`, `CvPADLIST`, `CvFILE`, `CvISXSUB`) — no
+//! hand-written struct pokes. `proto()` composes `SvPOK` +
+//! `SvPVX_const` + `SvCUR` because `CvPROTO` itself is on the
+//! macrogen skip list (see `libperl-sys/skip-codegen.txt`).
+//!
+//! Like [`Sv`](crate::Sv), a `Cv` does **not** own its referent:
+//! dropping it is a no-op. The `#[xs_sub]` proc-macro recognises a
+//! bare `Cv` parameter as "caller must pass a CODE reference" and
+//! generates the `SvROK` + `SVt_PVCV` check + croak in the
+//! trampoline (see `xs_sub.rs` `ArgKind::InCvRef`).
+
+use std::ptr::NonNull;
+
+use libperl_sys::{CV, OP, PADLIST, SV, svtype};
+
+/// Non-null pointer to a Perl `CV`. Same ABI as `*mut CV`.
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct Cv(NonNull<CV>);
+
+impl Cv {
+    /// Wrap a raw `*mut CV` without checking for null.
+    ///
+    /// # Safety
+    /// Caller must guarantee `p` is non-null and points to a valid CV
+    /// for at least the lifetime of the resulting `Cv`.
+    #[inline]
+    pub unsafe fn from_raw_unchecked(p: *mut CV) -> Self {
+        debug_assert!(!p.is_null(), "Cv::from_raw_unchecked received a null pointer");
+        Cv(unsafe { NonNull::new_unchecked(p) })
+    }
+
+    /// Wrap a raw `*mut CV`, returning `None` on null input.
+    #[inline]
+    pub fn from_raw(p: *mut CV) -> Option<Self> {
+        NonNull::new(p).map(Cv)
+    }
+
+    /// Dereference a Perl-level coderef SV (`\&sub`, `sub {...}`)
+    /// into its CV. Returns `None` when `sv` is null, not a
+    /// reference, or references something other than a CODE value.
+    #[inline]
+    pub fn from_coderef(sv: *mut SV) -> Option<Cv> {
+        if sv.is_null() || unsafe { libperl_sys::SvROK(sv) } == 0 {
+            return None;
+        }
+        let target = unsafe { libperl_sys::SvRV(sv) };
+        if unsafe { libperl_sys::SvTYPE(target) } != svtype::SVt_PVCV {
+            return None;
+        }
+        Some(unsafe { Cv::from_raw_unchecked(target as *mut CV) })
+    }
+
+    /// Raw `*mut CV` for FFI calls.
+    #[inline]
+    pub fn as_ptr(&self) -> *mut CV {
+        self.0.as_ptr()
+    }
+
+    /// True when this CV is an XSUB (C-implemented). XSUBs have no
+    /// OP tree; `root` / `start` / `padlist` return null for them.
+    #[inline]
+    pub fn is_xsub(&self) -> bool {
+        unsafe { libperl_sys::CvISXSUB(self.as_ptr()) != 0 }
+    }
+
+    /// Root of the CV's OP tree (`CvROOT`), or null for XSUBs.
+    #[inline]
+    pub fn root(&self) -> *const OP {
+        if self.is_xsub() {
+            std::ptr::null()
+        } else {
+            unsafe { libperl_sys::CvROOT(self.as_ptr()) }
+        }
+    }
+
+    /// First OP in execution order (`CvSTART`), or null for XSUBs.
+    #[inline]
+    pub fn start(&self) -> *const OP {
+        if self.is_xsub() {
+            std::ptr::null()
+        } else {
+            unsafe { libperl_sys::CvSTART(self.as_ptr()) }
+        }
+    }
+
+    /// The CV's PADLIST (lexical scratchpad), or null for XSUBs.
+    #[inline]
+    pub fn padlist(&self) -> *const PADLIST {
+        if self.is_xsub() {
+            std::ptr::null()
+        } else {
+            unsafe { libperl_sys::CvPADLIST(self.as_ptr()) }
+        }
+    }
+
+    /// Source file the sub was compiled from (`CvFILE`);
+    /// `"(eval N)"` for string-eval'd subs.
+    pub fn file(&self) -> Option<String> {
+        let p = unsafe { libperl_sys::CvFILE(self.as_ptr()) };
+        if p.is_null() {
+            None
+        } else {
+            Some(
+                unsafe { std::ffi::CStr::from_ptr(p) }
+                    .to_string_lossy()
+                    .into_owned(),
+            )
+        }
+    }
+
+    /// The sub's prototype string (`CvPROTO`), if any. A CV stores
+    /// its prototype in its own PV slot, so this is `SvPOK` +
+    /// `SvPVX_const`/`SvCUR` on the CV itself.
+    pub fn proto(&self) -> Option<String> {
+        let sv = self.as_ptr() as *mut SV;
+        unsafe {
+            if libperl_sys::SvPOK(sv) == 0 {
+                return None;
+            }
+            let pv = libperl_sys::SvPVX_const(sv);
+            if pv.is_null() {
+                return None;
+            }
+            let len = libperl_sys::SvCUR(sv);
+            let bytes = std::slice::from_raw_parts(pv as *const u8, len as usize);
+            Some(String::from_utf8_lossy(bytes).into_owned())
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,9 @@ pub use perl::*;
 pub mod sv;
 pub use sv::*;
 
+pub mod cv;
+pub use cv::*;
+
 pub mod rv;
 pub use rv::*;
 

--- a/xs-demo-mytest2/src/lib.rs
+++ b/xs-demo-mytest2/src/lib.rs
@@ -7,7 +7,7 @@
 
 use std::ffi::CStr;
 
-use libperl_rs::{xs_boot, xs_sub, Av, Hv, IV, NV, Perl, Rv, SV, Sv, UV};
+use libperl_rs::{xs_boot, xs_sub, Av, Cv, Hv, IV, NV, Perl, Rv, SV, Sv, UV};
 
 /// `Mytest2::foo($i, $l, $str)` — perlxstut EXAMPLE 4 shape.
 ///
@@ -243,6 +243,43 @@ fn multi_statfs(my_perl: &Perl, paths: &Av) -> Rv<Hv> {
     result.into_rv(my_perl)
 }
 
+/// `Mytest2::code_file($coderef)` — CvFILE of the referenced sub
+/// (`"(eval N)"` for string-eval'd subs). Demonstrates the `Cv`
+/// argument kind: the trampoline checks the caller passed a CODE
+/// reference and croaks otherwise.
+#[xs_sub]
+fn code_file(cv: Cv) -> String {
+    cv.file().unwrap_or_default()
+}
+
+/// `Mytest2::code_is_xsub($coderef)` — whether the referenced sub is
+/// an XSUB (C-implemented, no OP tree).
+#[xs_sub]
+fn code_is_xsub(cv: Cv) -> bool {
+    cv.is_xsub()
+}
+
+/// `Mytest2::code_proto($coderef)` — the sub's prototype string, or
+/// `""` when it has none.
+#[xs_sub]
+fn code_proto(cv: Cv) -> String {
+    cv.proto().unwrap_or_default()
+}
+
+/// `Mytest2::code_op_count($coderef)` — number of ops on the sub's
+/// execution-order chain (CvSTART → op_next → …); 0 for XSUBs.
+/// Demonstrates OP-tree access through `Cv::start`.
+#[xs_sub]
+fn code_op_count(cv: Cv) -> IV {
+    let mut n: IV = 0;
+    let mut op = cv.start();
+    while !op.is_null() {
+        n += 1;
+        op = unsafe { (*op).op_next as *const _ };
+    }
+    n
+}
+
 xs_boot! {
     package = "Mytest2";
     subs = [foo, shout, byte_len, statfs, words, identity, maybe_sv,
@@ -250,5 +287,6 @@ xs_boot! {
             wrap_iv, wrap_uv, wrap_nv, wrap_pv,
             make_pair, make_record, maybe_pair,
             sum_iv, av_len_demo, record_keys,
-            multi_statfs];
+            multi_statfs,
+            code_file, code_is_xsub, code_proto, code_op_count];
 }

--- a/xs-demo-mytest2/t/09_cv.t
+++ b/xs-demo-mytest2/t/09_cv.t
@@ -1,0 +1,36 @@
+use Test2::V0;
+
+use Mytest2;
+
+# `Cv` argument kind — the caller passes a CODE reference, the body
+# receives a Cv handle. Primary use case: static analysis of
+# string-eval'd anonymous subs.
+{
+    my $anon = eval 'sub { 1 + 2 }';
+    ok(!Mytest2::code_is_xsub($anon), 'eval anon sub is not an XSUB');
+    like(Mytest2::code_file($anon), qr/eval/, 'CvFILE mentions eval');
+    cmp_ok(Mytest2::code_op_count($anon), '>', 2, 'op chain non-trivial');
+}
+
+# XSUBs are visible as such and have no OP chain.
+{
+    ok(Mytest2::code_is_xsub(\&Mytest2::code_is_xsub), 'XS sub reports is_xsub');
+    is(Mytest2::code_op_count(\&Mytest2::code_is_xsub), 0, 'XSUB has no op chain');
+}
+
+# Prototype access (CvPROTO composed from SvPOK + SvPVX_const/SvCUR).
+{
+    my $with_proto = eval 'sub ($$) { }';
+    is(Mytest2::code_proto($with_proto), '$$', 'prototype string');
+    my $anon = eval 'sub { }';
+    is(Mytest2::code_proto($anon), '', 'no prototype -> empty string');
+}
+
+# Trampoline type check.
+like(dies { Mytest2::code_file(42) }, qr/must be a CODE reference/,
+    'non-ref croaks');
+like(dies { Mytest2::code_file([]) }, qr/must be a CODE reference/,
+    'non-code ref croaks');
+like(dies { Mytest2::code_file() }, qr/Usage:/, 'arity croak');
+
+done_testing;


### PR DESCRIPTION
First slice of Step 2 in `docs/plan/README.md` (Cv/Op newtypes for OP-tree walkers): the minimal API a static-analysis client needs to get from a Perl coderef to its OP tree.

## What's included

- **`Cv` newtype** (`src/cv.rs`): `NonNull<CV>` handle with `root` / `start` / `padlist` / `file` / `proto` / `is_xsub` and `Cv::from_coderef`. All accessors delegate to the macrogen-emitted official API (`CvROOT`, `CvSTART`, `CvPADLIST`, `CvFILE`, `CvISXSUB`); XSUBs are guarded before touching the `xcv_root_u` / `xcv_padlist_u` unions. `proto()` composes `SvPOK` + `SvPVX_const` + `SvCUR` since `CvPROTO` is on the macrogen skip list.
- **`#[xs_sub]` `Cv` argument kind** (`ArgKind::InCvRef`): a bare `Cv` parameter makes the trampoline check `SvROK` + `SVt_PVCV` and croak `argument `x` must be a CODE reference` on mismatch — same shape as the existing `&Av` / `&Hv` handling.
- **libperl-sys allowlist additions**: `op_argcheck_aux` (signature `argcheck` aux struct) and `MDEREF_.*` (multideref aux action constants), so downstream analyzers don't need local `#[repr(C)]` mirrors.
- **Demos + tests**: `xs-demo-mytest2` gains `code_file` / `code_is_xsub` / `code_proto` / `code_op_count` and `t/09_cv.t`.
- **Cargo.lock**: `libperl-macrogen` 0.1.5 → 0.1.6. Without this the workspace does not build on C23 toolchains (Fedora 41+/GCC 15+), where glibc's `memchr` expands to `_Generic` — see hkoba/libperl-macrogen#1.

## Verification

- `cargo test` green across the workspace, including the `Mytest2` smoke test running `prove t/*.t` (9 files, with the new `t/09_cv.t`).
- Dogfooded by a downstream OP-tree analyzer: its XS entry points switched to the `Cv` argument kind and its local `op_argcheck_aux` / `MDEREF_*` mirrors were replaced by the new allowlisted items; 72 Perl-side tests pass and valgrind reports 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)